### PR TITLE
Add CI workflow to build Jekyll site

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,19 @@
+name: Jekyll Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+      - name: Build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Jekyll site on push and PR

## Testing
- `bundle _2.6.9_ install --jobs 4 --retry 3` *(fails: lockfile unreadable)*
- `bundle exec jekyll build` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff5feff88325a912bcdc348b201d